### PR TITLE
Use macro for the cmake build directory instead of hardcoding redhat-linux-build

### DIFF
--- a/rpm/xrdhttp-pelican.spec
+++ b/rpm/xrdhttp-pelican.spec
@@ -36,13 +36,13 @@ Requires: xrootd-client <  1:%{xrootd_current_major}.%{xrootd_next_minor}.0
 %build
 
 %cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-pushd redhat-linux-build
+pushd %__cmake_builddir
 make VERBOSE=1 %{?_smp_mflags}
 popd
 
 %install
 rm -rf $RPM_BUILD_ROOT
-pushd redhat-linux-build
+pushd %__cmake_builddir
 make install DESTDIR=$RPM_BUILD_ROOT
 popd
 


### PR DESCRIPTION
(the latter is not valid on el8)

