### PR TITLE
Add prestage and eviction functionality to the plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         sudo curl -L https://xrootd.web.cern.ch/repo/RPM-GPG-KEY.txt -o /etc/apt/trusted.gpg.d/xrootd.asc
         sudo /bin/sh -c 'echo "deb https://xrootd.web.cern.ch/ubuntu noble stable" >> /etc/apt/sources.list.d/xrootd.list'
-        sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-private-dev libxrootd-dev libxrootd-server-dev libgtest-dev
+        sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-private-dev libxrootd-dev libxrootd-server-dev libgtest-dev xrootd-scitokens-plugins
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ project( xrdhttp-pelican )
 
 find_package( XRootD REQUIRED )
 
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 20)
 
 find_package( Threads REQUIRED )
 
-if( CMAKE_COMPILER_IS_GNUCXX )
+if( CMAKE_BUILD_TYPE STREQUAL Debug )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror" )
 endif()
 if(NOT APPLE)
@@ -28,7 +28,7 @@ add_subdirectory(tests)
 
 include_directories(${XRootD_INCLUDE_DIR})
 
-add_library(XrdHttpPelicanObj OBJECT src/XrdHttpPelican.cc)
+add_library(XrdHttpPelicanObj OBJECT src/XrdHttpPelican.cc src/Prestage.cc)
 target_link_libraries(XrdHttpPelicanObj ${XRootD_HTTP_LIBRARIES} ${XRootD_UTILS_LIBRARIES} Threads::Threads)
 set_target_properties(XrdHttpPelicanObj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
@@ -40,11 +40,10 @@ endif()
 add_library(XrdHttpPelican MODULE "$<TARGET_OBJECTS:XrdHttpPelicanObj>")
 target_link_libraries(XrdHttpPelican XrdHttpPelicanObj)
 
+SET(LIBRARY_SUFFIX ".so")
 if(APPLE)
-  SET(LIBRARY_SUFFIX ".dylib")
   set_target_properties(XrdHttpPelican PROPERTIES OUTPUT_NAME "XrdHttpPelican-${XRootD_VERSION_MAJOR}" SUFFIX ${LIBRARY_SUFFIX})
 else()
-  SET(LIBRARY_SUFFIX ".so")
   set_target_properties(XrdHttpPelican PROPERTIES OUTPUT_NAME "XrdHttpPelican-${XRootD_VERSION_MAJOR}" SUFFIX ${LIBRARY_SUFFIX} LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols")
 endif()
 

--- a/rpm/xrdhttp-pelican.spec
+++ b/rpm/xrdhttp-pelican.spec
@@ -56,4 +56,3 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 * Mon Dec 23 2024 Brian Bockelman <bbockelman@morgridge.org> - 0.0.3-1
 - First build of the xrdhttp-pelican plugin
-

--- a/src/Prestage.cc
+++ b/src/Prestage.cc
@@ -206,13 +206,15 @@ int PrestageRequestManager::PrestageRequest::WaitFor(
     return m_status;
 }
 
-PrestageRequestManager::PrestageRequestManager(XrdOucEnv &xrdEnv, XrdSysError &eDest)
-    : m_log(eDest)
-{
+PrestageRequestManager::PrestageRequestManager(XrdOucEnv &xrdEnv,
+                                               XrdSysError &eDest)
+    : m_log(eDest) {
     std::call_once(m_init_once, [&] {
         m_oss = static_cast<XrdOss *>(xrdEnv.GetPtr("XrdOss*"));
         if (!m_oss) {
-            m_log.Log(LogMask::Error, "RequestManager", "XrdOss plugin is not configured; prestage functionality disabled");
+            m_log.Log(LogMask::Error, "RequestManager",
+                      "XrdOss plugin is not configured; prestage functionality "
+                      "disabled");
         }
     });
 }
@@ -221,7 +223,9 @@ bool PrestageRequestManager::Produce(
     PrestageRequestManager::PrestageRequest &handler) {
 
     if (!m_oss) {
-        m_log.Log(LogMask::Debug, "RequestManager", "XrdOss plugin is not configured; prestage functionality disabled");
+        m_log.Log(
+            LogMask::Debug, "RequestManager",
+            "XrdOss plugin is not configured; prestage functionality disabled");
         return false;
     }
 
@@ -239,9 +243,8 @@ bool PrestageRequestManager::Produce(
         auto iter = m_pool_map.find(handler.GetIdentifier());
         if (iter == m_pool_map.end()) {
             queue = std::make_shared<PrestageQueue>(handler.GetIdentifier(),
-                                                       *this, *m_oss);
-            m_pool_map.insert(
-                iter, {handler.GetIdentifier(), queue});
+                                                    *this, *m_oss);
+            m_pool_map.insert(iter, {handler.GetIdentifier(), queue});
         } else {
             queue = iter->second;
         }

--- a/src/Prestage.cc
+++ b/src/Prestage.cc
@@ -1,0 +1,250 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "XrdHttpPelican.hh"
+
+#include <XrdOss/XrdOss.hh>
+#include <XrdOuc/XrdOucEnv.hh>
+#include <XrdSys/XrdSysError.hh>
+
+#include <string>
+#include <thread>
+
+#include <fcntl.h>
+
+using namespace XrdHttpPelican;
+using namespace XrdHttpPelican::detail;
+
+decltype(PrestageRequestManager::m_pool_map) PrestageRequestManager::m_pool_map;
+decltype(PrestageRequestManager::m_init_once)
+    PrestageRequestManager::m_init_once;
+decltype(PrestageRequestManager::m_oss) PrestageRequestManager::m_oss;
+decltype(PrestageRequestManager::m_mutex) PrestageRequestManager::m_mutex;
+
+PrestageRequestManager::PrestageQueue::PrestageWorker::PrestageWorker(
+    const std::string &label, XrdOss &oss, PrestageQueue &queue)
+    : m_label(label), m_oss(oss), m_queue(queue) {}
+
+void PrestageRequestManager::PrestageQueue::PrestageWorker::RunStatic(
+    PrestageWorker *myself) {
+    myself->Run();
+}
+
+void PrestageRequestManager::PrestageQueue::PrestageWorker::Prestage(
+    PrestageRequestManager::PrestageRequest &request) {
+    auto fp = m_oss.newFile("Prestage Worker");
+
+    ssize_t rc =
+        fp->Open(request.GetPath().c_str(), O_RDONLY, 0, request.GetEnv());
+    if (rc < 0) {
+        if (rc == -ENOENT) {
+            request.SetDone(404, "Object does not exist");
+            return;
+        } else if (rc == -EISDIR) {
+            request.SetDone(409, "Object is a directory");
+            return;
+        } else {
+            request.SetDone(500, "Unknown error when preparing for prestage");
+            return;
+        }
+    }
+    off_t off{0};
+    auto lastUpdate = std::chrono::steady_clock::now();
+    while ((rc = fp->Read(off, 64 * 1024)) > 0) {
+        off += rc;
+        if (std::chrono::steady_clock::now() - lastUpdate >
+            std::chrono::milliseconds(200)) {
+            request.SetProgress(off);
+        }
+    }
+    fp->Close();
+    if (rc < 0) {
+        std::stringstream ss;
+        ss << "I/O failure when prestaging: " << strerror(-rc);
+        request.SetDone(500, ss.str());
+        return;
+    }
+    request.SetDone(200, "Prestage successful");
+    return;
+}
+
+void PrestageRequestManager::PrestageQueue::PrestageWorker::Run() {
+    while (true) {
+        auto request = m_queue.TryConsume();
+        if (!request) {
+            request = m_queue.ConsumeUntil(std::chrono::minutes(1));
+            if (!request) {
+                break;
+            }
+        }
+        Prestage(*request);
+    }
+
+    m_queue.Done(this);
+}
+
+void PrestageRequestManager::PrestageQueue::Done(PrestageWorker *worker) {
+    std::unique_lock lock(m_mutex);
+    m_idle--;
+    std::erase_if(m_workers, [&](std::unique_ptr<PrestageWorker> &other) {
+        return other.get() == worker;
+    });
+
+    if (m_workers.empty()) {
+        m_parent.Done(m_label);
+    }
+}
+
+void PrestageRequestManager::Done(const std::string &ident) {
+    std::unique_lock lock(m_mutex);
+
+    auto iter = m_pool_map.find(ident);
+    if (iter != m_pool_map.end()) {
+        m_pool_map.erase(iter);
+    }
+}
+
+bool PrestageRequestManager::PrestageQueue::Produce(PrestageRequest &handler) {
+    std::unique_lock lk{m_mutex};
+    if (m_ops.size() == m_max_pending_ops) {
+        return false;
+    }
+
+    m_ops.push_back(&handler);
+    m_cv.notify_one();
+
+    if (!m_idle && m_workers.size() < m_max_workers) {
+        m_workers.push_back(
+            std::make_unique<
+                PrestageRequestManager::PrestageQueue::PrestageWorker>(
+                handler.GetIdentifier(), m_oss, *this));
+        std::thread t(
+            PrestageRequestManager::PrestageQueue::PrestageWorker::RunStatic,
+            m_workers.back().get());
+        t.detach();
+    }
+    lk.unlock();
+
+    return true;
+}
+
+PrestageRequestManager::PrestageRequest &
+PrestageRequestManager::PrestageQueue::Consume() {
+    std::unique_lock<std::mutex> lk(m_mutex);
+    m_idle++;
+    m_cv.wait(lk, [&] { return m_ops.size() > 0; });
+    m_idle--;
+
+    auto result = std::move(m_ops.front());
+    m_ops.pop_front();
+
+    return *result;
+}
+
+PrestageRequestManager::PrestageRequest *
+PrestageRequestManager::PrestageQueue::TryConsume() {
+    std::unique_lock<std::mutex> lk(m_mutex);
+    if (m_ops.size() == 0) {
+        return nullptr;
+    }
+
+    auto result = m_ops.front();
+    m_ops.pop_front();
+
+    return result;
+}
+
+PrestageRequestManager::PrestageRequest *
+PrestageRequestManager::PrestageQueue::ConsumeUntil(
+    std::chrono::steady_clock::duration dur) {
+    std::unique_lock<std::mutex> lk(m_mutex);
+    m_idle++;
+    m_cv.wait_for(lk, dur, [&] { return m_ops.size() > 0; });
+    m_idle--;
+    if (m_ops.size() == 0) {
+        return nullptr;
+    }
+
+    auto result = m_ops.front();
+    m_ops.pop_front();
+
+    return result;
+}
+
+void PrestageRequestManager::PrestageRequest::SetProgress(off_t offset) {
+    m_prestage_offset.store(offset, std::memory_order_relaxed);
+}
+
+void PrestageRequestManager::PrestageRequest::SetDone(int status,
+                                                      const std::string &msg) {
+    std::unique_lock lock(m_mutex);
+    m_status = status;
+    m_message = msg;
+    m_cv.notify_one();
+}
+
+int PrestageRequestManager::PrestageRequest::WaitFor(
+    std::chrono::steady_clock::duration dur) {
+    std::unique_lock lock(m_mutex);
+    m_cv.wait_for(lock, dur, [&] { return m_status >= 0; });
+
+    return m_status;
+}
+
+PrestageRequestManager::PrestageRequestManager(XrdOucEnv &xrdEnv, XrdSysError &eDest)
+    : m_log(eDest)
+{
+    std::call_once(m_init_once, [&] {
+        m_oss = static_cast<XrdOss *>(xrdEnv.GetPtr("XrdOss*"));
+        if (!m_oss) {
+            m_log.Log(LogMask::Error, "RequestManager", "XrdOss plugin is not configured; prestage functionality disabled");
+        }
+    });
+}
+
+bool PrestageRequestManager::Produce(
+    PrestageRequestManager::PrestageRequest &handler) {
+
+    if (!m_oss) {
+        m_log.Log(LogMask::Debug, "RequestManager", "XrdOss plugin is not configured; prestage functionality disabled");
+        return false;
+    }
+
+    std::shared_ptr<PrestageQueue> queue;
+    {
+        m_mutex.lock_shared();
+        std::lock_guard guard{m_mutex, std::adopt_lock};
+        auto iter = m_pool_map.find(handler.GetIdentifier());
+        if (iter != m_pool_map.end()) {
+            queue = iter->second;
+        }
+    }
+    if (!queue) {
+        std::lock_guard guard(m_mutex);
+        auto iter = m_pool_map.find(handler.GetIdentifier());
+        if (iter == m_pool_map.end()) {
+            queue = std::make_shared<PrestageQueue>(handler.GetIdentifier(),
+                                                       *this, *m_oss);
+            m_pool_map.insert(
+                iter, {handler.GetIdentifier(), queue});
+        } else {
+            queue = iter->second;
+        }
+    }
+    return queue->Produce(handler);
+}

--- a/src/XrdHttpPelican.cc
+++ b/src/XrdHttpPelican.cc
@@ -16,9 +16,19 @@
  *
  ***************************************************************/
 
-#include "private/XrdHttp/XrdHttpExtHandler.hh"
+#include "XrdHttpPelican.hh"
 
-#include "XrdSys/XrdSysError.hh"
+#include <XrdAcc/XrdAccAuthorize.hh>
+#include <XrdSfs/XrdSfsInterface.hh>
+#include <XrdOfs/XrdOfsFSctl_PI.hh>
+#include <XrdOss/XrdOss.hh>
+#include <XrdOuc/XrdOucEnv.hh>
+#include <XrdOuc/XrdOucErrInfo.hh>
+#include <XrdOuc/XrdOucGatherConf.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdSec/XrdSecEntityAttr.hh>
+#include <XrdSfs/XrdSfsInterface.hh>
+#include <XrdSys/XrdSysError.hh>
 #include <XrdVersion.hh>
 
 #include <arpa/inet.h>
@@ -34,62 +44,84 @@
 #include <thread>
 #include <vector>
 
-class PelicanHandler : public XrdHttpExtHandler {
-  public:
-    PelicanHandler(XrdSysError *log, const char *config, XrdOucEnv *myEnv);
-    virtual ~PelicanHandler();
+using namespace XrdHttpPelican;
+using namespace XrdHttpPelican::detail;
 
-    virtual bool MatchesPath(const char *verb, const char *path) override;
-    virtual int ProcessReq(XrdHttpExtReq &req) override;
-    virtual int Init(const char *cfgfile) override { return 0; }
+std::once_flag Handler::m_info_launch;
+int Handler::m_info_fd = -1;
+std::string Handler::m_ca_file;
+std::string Handler::m_cert_file;
+std::filesystem::path Handler::m_api_root{"/api/v1.0/pelican"};
+decltype(Handler::m_acc) Handler::m_acc{nullptr};
+decltype(Handler::m_is_cache) Handler::m_is_cache{false};
+decltype(Handler::m_sfs) Handler::m_sfs{nullptr};
 
-  private:
-    // A thread that does nothing but listens for the parent's pipe to
-    // close.  When it does close, send a SIGTERM to the existing
-    // process followed by a SIGTERM.
-    //
-    // This allows XRootD to auto-info when Pelican goes away.
-    void InfoThread();
+namespace {
 
-    // Ensure that the info thread is only started once.
-    static std::once_flag m_info_launch;
+std::pair<bool, std::string> urlunquote(const std::string_view encoded) {
+    std::string decoded;
+    decoded.reserve(encoded.size());
 
-    // The file descriptor to listen on for a pipe-based info.
-    static int m_info_fd;
+    for (size_t idx = 0; idx < encoded.size(); idx++) {
+        char c = encoded[idx];
+        if (c == '%') {
+            if (idx + 2 >= encoded.size()) {
+                return {false, ""};
+            }
+            char hex[3] = {encoded[idx + 1], encoded[idx + 2], '\0'};
+            idx += 3;
+            std::size_t pos;
+            try {
+                decoded += static_cast<char>(std::stoi(hex, &pos, 16));
+            } catch (std::invalid_argument const &exc) {
+                return {false, ""};
+            }
+            if (pos != 2) {
+                return {false, ""};
+            }
+        } else if (c == '+') {
+            decoded += ' ';
+        } else {
+            decoded += c;
+        }
+    }
 
-    // The location of the CA file for this process
-    static std::string m_ca_file;
+    return {true, decoded};
+}
 
-    // The location of the host certificate for this process
-    static std::string m_cert_file;
+std::string LogMaskToString(int mask) {
+    if (mask == LogMask::All) {
+            return "all";
+    }
 
-    // Send a SIGTERM to self, followed by a 5 second sleep, followed
-    // by a SIGKILL (until the process exits).
-    void ShutdownSelf();
+    bool has_entry = false;
+    std::stringstream ss;
+    if (mask & LogMask::Debug) {
+            ss << (has_entry ? ", " : "") << "debug";
+            has_entry = true;
+    }
+    if (mask & LogMask::Info) {
+            ss << (has_entry ? ", " : "") << "info";
+            has_entry = true;
+    }
+    if (mask & LogMask::Warning) {
+            ss << (has_entry ? ", " : "") << "warning";
+            has_entry = true;
+    }
+    if (mask & LogMask::Error) {
+            ss << (has_entry ? ", " : "") << "error";
+            has_entry = true;
+    }
+    return ss.str();
+}
 
-    // Process a message from the info file descriptor; this pipe
-    // provides the ability for the parent process to update the CA
-    // and TLS certificate files.
-    void ProcessMessage();
+} // namespace
 
-    // Atomically overwrite a location given a file descriptor with
-    // the new contents.
-    void AtomicOverwriteFile(int fd, const std::string &loc);
+Handler::~Handler() {}
 
-    // Logger associated with the object
-    XrdSysError &m_log;
-};
-
-std::once_flag PelicanHandler::m_info_launch;
-int PelicanHandler::m_info_fd = -1;
-std::string PelicanHandler::m_ca_file;
-std::string PelicanHandler::m_cert_file;
-
-PelicanHandler::~PelicanHandler() {}
-
-PelicanHandler::PelicanHandler(XrdSysError *log, const char * /*config*/,
-                               XrdOucEnv * /*myEnv*/)
-    : m_log(*log) {
+Handler::Handler(XrdSysError *log, const char * configfn,
+                               XrdOucEnv *xrdEnv)
+    : m_log(*log), m_manager(*xrdEnv, *log) {
     std::call_once(m_info_launch, [&] {
         auto fd_char = getenv("XRDHTTP_PELICAN_INFO_FD");
         if (fd_char) {
@@ -123,12 +155,71 @@ PelicanHandler::PelicanHandler(XrdSysError *log, const char * /*config*/,
                        "set; cannot update the host certificate");
         }
 
-        std::thread t(&PelicanHandler::InfoThread, this);
+        XrdOucGatherConf pelicanhandler_conf("pelican.", &m_log);
+        int result;
+        if ((result = pelicanhandler_conf.Gather(configfn, XrdOucGatherConf::full_lines)) < 0) {
+                m_log.Emsg("Config", -result, "parsing config file", configfn);
+                throw std::invalid_argument("Failed to parse the configuration file");
+        }
+        m_log.setMsgMask(LogMask::Warning);
+        char *temporary;
+        while ((temporary = pelicanhandler_conf.GetLine())) {
+            auto attribute = pelicanhandler_conf.GetToken();
+
+            if (strcmp(attribute, "pelican.trace")) {
+                continue;
+            }
+
+            char *val = nullptr;
+            if (!(val = pelicanhandler_conf.GetToken())) {
+                    m_log.Emsg("Config",
+                                    "pelican.trace requires an argument.  Usage: "
+                                    "pelican.trace [all|error|warning|info|debug|none]");
+                    throw std::invalid_argument("Invalid configuration value in pelican.trace");
+            }
+            do {
+                if (!strcmp(val, "all")) {
+                    m_log.setMsgMask(m_log.getMsgMask() | LogMask::All);
+                } else if (!strcmp(val, "error")) {
+                    m_log.setMsgMask(m_log.getMsgMask() | LogMask::Error);
+                } else if (!strcmp(val, "warning")) {
+                    m_log.setMsgMask(m_log.getMsgMask() | LogMask::Warning);
+                } else if (!strcmp(val, "info")) {
+                    m_log.setMsgMask(m_log.getMsgMask() | LogMask::Info);
+                } else if (!strcmp(val, "debug")) {
+                    m_log.setMsgMask(m_log.getMsgMask() | LogMask::Debug);
+                } else if (!strcmp(val, "none")) {
+                    m_log.setMsgMask(0);
+                } else {
+                    m_log.Emsg("Config",
+                                     "pelican.trace encountered an unknown directive:", val);
+                    throw std::invalid_argument("Invalid configuration value in pelican.trace");
+                }
+            } while ((val = pelicanhandler_conf.GetToken()));
+            m_log.Emsg("Config", "Logging levels enabled -",
+                         LogMaskToString(m_log.getMsgMask()).c_str());
+        }
+
+
+        m_acc = reinterpret_cast<XrdAccAuthorize *>(
+            xrdEnv->GetPtr("XrdAccAuthorize*"));
+
+        long one;
+        m_is_cache = XrdOucEnv::Import("XRDPFC", one);
+
+        if (m_is_cache) {
+            m_sfs = reinterpret_cast<XrdSfsFileSystem *>(xrdEnv->GetPtr("XrdSfsFileSystem*"));
+            if (!m_sfs) {
+                m_log.Emsg("PelicanHandler", "Filesystem control plugin is not available; cannot manage eviction");
+            }
+        }
+
+        std::thread t(&Handler::InfoThread, this);
         t.detach();
     });
 }
 
-void PelicanHandler::InfoThread() {
+void Handler::InfoThread() {
     if (m_info_fd < 0) {
         return;
     }
@@ -147,7 +238,7 @@ void PelicanHandler::InfoThread() {
     }
 }
 
-void PelicanHandler::ProcessMessage() {
+void Handler::ProcessMessage() {
     if (m_info_fd < 0) {
         return;
     }
@@ -224,7 +315,7 @@ void PelicanHandler::ProcessMessage() {
     }
 }
 
-void PelicanHandler::AtomicOverwriteFile(int fd, const std::string &loc) {
+void Handler::AtomicOverwriteFile(int fd, const std::string &loc) {
     std::vector<char> loc_template;
     loc_template.resize(loc.size() + 7 + 1);
     loc_template[loc.size() + 7] = '\0';
@@ -304,7 +395,7 @@ void PelicanHandler::AtomicOverwriteFile(int fd, const std::string &loc) {
     }
 }
 
-void PelicanHandler::ShutdownSelf() {
+void Handler::ShutdownSelf() {
     auto self = getpid();
     auto rv = kill(self, SIGTERM);
     if (rv == -1) {
@@ -322,11 +413,218 @@ void PelicanHandler::ShutdownSelf() {
     }
 }
 
-bool PelicanHandler::MatchesPath(const char *verb, const char * /*path*/) {
-    return false;
+bool Handler::MatchesPath(const char *verb, const char *path) {
+    return m_is_cache && !strcmp(verb, "GET") &&
+           (!strcmp(path, "/pelican/api/v1.0/prestage") ||
+            !strcmp(path, "/pelican/api/v1.0/evict"));
 }
 
-int PelicanHandler::ProcessReq(XrdHttpExtReq &req) { return -1; }
+int Handler::ProcessReq(XrdHttpExtReq &req) {
+    auto iter = req.headers.find("xrd-http-query");
+    if (iter == req.headers.end()) {
+        m_log.Emsg("ProcessReq", "Missing internally-generated server data",
+                   req.resource.c_str());
+        req.SendSimpleResp(500, "Bad Request", nullptr,
+                           "Prestage request missing internal server data",
+                           0);
+        return 1;
+    }
+    auto &query = iter->second;
+    if (query.empty()) {
+        m_log.Emsg("ProcessReq", "Missing query parameter from request", req.resource.c_str());
+        req.SendSimpleResp(400, "Bad Request", nullptr,
+                           "Prestage command request requires the `path` query parameter",
+                           0);
+        return 1;
+    }
+    std::string_view query_params = query;
+    std::string_view path_view;
+    while (!query_params.empty()) {
+        if (query_params[0] == '&') {
+            query_params = query_params.substr(1);
+            continue;
+        }
+        auto pos = query_params.find('&');
+        auto param = query_params.substr(0, pos);
+        if (pos == std::string::npos) {
+            query_params = "";
+        } else {
+            query_params = query_params.substr(pos + 1);
+        }
+        auto equal_pos = param.find('=');
+        if (equal_pos == std::string::npos) {
+            continue;
+        }
+        auto param_name = param.substr(0, equal_pos);
+        if (param_name != "path") {
+            continue;
+        }
+        path_view = param.substr(equal_pos + 1);
+    }
+    auto [success, path_str] = urlunquote(path_view);
+    if (!success) {
+        req.SendSimpleResp(400, "Bad Request", nullptr,
+                           "Failed to unquote `path` query parameter value", 0);
+        return 1;
+    }
+
+    std::filesystem::path path(path_str);
+    path = path.lexically_normal();
+    if (!path.is_absolute()) {
+        req.SendSimpleResp(400, "Bad Request", nullptr,
+                           "Prestage request must be an absolute path", 0);
+    }
+
+    std::filesystem::path resource_clean(req.resource);
+
+    if (!strcmp("/pelican/api/v1.0/prestage", resource_clean.c_str())) {
+        return PrestageReq(path, req);
+    } else {
+        return EvictReq(path, req);
+    }
+}
+
+int Handler::EvictReq(const std::string &path, XrdHttpExtReq &req) {
+    auto &ent = req.GetSecEntity();
+    if (m_acc) {
+        if (!m_acc->Access(&ent, path.c_str(), AOP_Delete)) {
+            m_log.Log(LogMask::Info, "evict", "Permission denied to evict path", path.c_str());
+            req.SendSimpleResp(403, "Forbidden", nullptr,
+                               "Permission denied to evict path", 0);
+            return 1;
+        }
+    }
+
+    std::string message = "evict " + path;
+    XrdOucErrInfo einfo;
+    XrdSfsFSctl myData;
+    myData.Arg1 = "evict";
+    myData.Arg1Len = 1;
+    myData.Arg2Len = -2;
+    const char *myArgs[2];
+    myArgs[0] = path.c_str();
+    myArgs[1] = req.headers.find("xrd-http-query")->second.c_str();
+    myData.ArgP = myArgs;
+    int fsctlRes = m_sfs->FSctl(SFS_FSCTL_PLUGXC, myData, einfo, &req.GetSecEntity());
+    bool locked = false;
+    if (fsctlRes == SFS_ERROR) {
+        auto ec = einfo.getErrInfo();
+        if (ec == ENOTTY) {
+            locked = true;
+        }
+    } else if (fsctlRes == 5) {
+        locked = true;
+    }
+    if (locked) {
+        m_log.Log(LogMask::Info, "evict", "Evict failed because path is locked:", path.c_str());
+        return req.SendSimpleResp(
+            423, "Locked", nullptr,
+            "Cannot evict file that is in-use by the cache", 0);
+    } else {
+        m_log.Log(LogMask::Info, "evict", "Evicted path", path.c_str());
+        return req.SendSimpleResp(200, "OK", nullptr,
+                                  "Cache eviction successful", 0);
+    }
+}
+
+int Handler::PrestageReq(const std::string &path, XrdHttpExtReq &req) {
+    auto &ent = req.GetSecEntity();
+    if (m_acc) {
+        if (!m_acc->Access(&ent, path.c_str(), AOP_Read)) {
+            req.SendSimpleResp(403, "Forbidden", nullptr,
+                               "Permission denied to prestage path", 0);
+            return 1;
+        }
+    }
+
+    m_log.Log(LogMask::Debug, "Prestage", "Handling prestage for path", path.c_str());
+    std::string user;
+    std::string vo{ent.vorg ? ent.vorg : ""};
+    if (ent.eaAPI && !ent.eaAPI->Get("token.subject", user)) {
+        std::string request_user;
+        if (ent.eaAPI->Get("request.name", request_user) &&
+            !request_user.empty()) {
+            user = request_user;
+        }
+    }
+    if (user.empty()) {
+        user = ent.name ? ent.name : "nobody";
+    }
+    if (!vo.empty()) {
+        user = vo + ":" + user;
+    }
+
+    XrdOucEnv env(nullptr, 0, &ent);
+    PrestageRequestManager::PrestageRequest request(user, path, env);
+    if (!m_manager.Produce(request)) {
+        req.SendSimpleResp(429, "Too Many Requests", nullptr,
+                           "Too many prestage requests at server", 0);
+    }
+
+    auto sent_resp = false;
+    int status;
+    while ((status = request.WaitFor(std::chrono::seconds(2))) <= 0) {
+        if (!sent_resp) {
+            if (req.StartChunkedResp(200, "OK", nullptr) < 0) {
+                m_log.Emsg("ProcessReq", "Failed to start response to client");
+                return -1;
+            }
+            sent_resp = true;
+        }
+        std::string resp;
+        if (request.IsActive()) {
+            resp = "status: active,offset=" +
+                   std::to_string(request.GetProgress());
+        } else {
+            resp = "status: queued";
+        }
+        if (req.ChunkResp(resp.c_str(), resp.size()) < 0) {
+            m_log.Emsg("ProcessReq", "Failed to send status report to client");
+            return -1;
+        }
+    }
+    std::string desc;
+    switch (status) {
+    case 200:
+        desc = "OK";
+        break;
+    case 401:
+        desc = "Unauthorized";
+        break;
+    case 403:
+        desc = "Forbidden";
+        break;
+    case 404:
+        desc = "File not found";
+        break;
+    case 409:
+        desc = "Resource is a directory";
+        break;
+    case 500:
+        desc = "Internal Server Error";
+        break;
+    default:
+        desc = "Internal Server Error";
+        status = 500;
+    }
+    if (!sent_resp) {
+        return req.SendSimpleResp(status, desc.c_str(), nullptr, nullptr, 0);
+    } else {
+        int rc;
+        if (status >= 300) {
+            auto resp = "failure: " + std::to_string(status) + "(" + desc +
+                        "): " + request.GetResults();
+            rc = req.ChunkResp(resp.c_str(), resp.size());
+        } else {
+            rc = req.ChunkResp("success: ok", 0);
+        }
+        if (rc < 0) {
+            m_log.Emsg("ProcessReq", "Failed to send final response to client");
+            return rc;
+        }
+        return req.ChunkResp(nullptr, 0);
+    }
+}
 
 extern "C" {
 
@@ -335,7 +633,11 @@ XrdVERSIONINFO(XrdHttpGetExtHandler, XrdHttpPelican);
 XrdHttpExtHandler *XrdHttpGetExtHandler(XrdSysError *log, const char *config,
                                         const char * /*parms*/,
                                         XrdOucEnv *myEnv) {
-    PelicanHandler *retval{nullptr};
+    Handler *retval{nullptr};
+
+    if (log) {
+        log = new XrdSysError(log->logger(), "pelican_");
+    }
 
     if (!config) {
         log->Emsg(
@@ -348,7 +650,7 @@ XrdHttpExtHandler *XrdHttpGetExtHandler(XrdSysError *log, const char *config,
         log->Emsg("PelicanHandler",
                   "Will load configuration for the Pelican handler from",
                   config);
-        retval = new PelicanHandler(log, config, myEnv);
+        retval = new Handler(log, config, myEnv);
     } catch (std::runtime_error &re) {
         log->Emsg("PelicanInitialize",
                   "Encountered a runtime failure when loading ", re.what());

--- a/src/XrdHttpPelican.hh
+++ b/src/XrdHttpPelican.hh
@@ -1,0 +1,221 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "private/XrdHttp/XrdHttpExtHandler.hh"
+
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <filesystem>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+class XrdAccAuthorize;
+class XrdOfsFSctl_PI;
+class XrdOss;
+class XrdOucEnv;
+class XrdSfsFileSystem;
+class XrdSysError;
+
+namespace XrdHttpPelican {
+
+namespace detail {
+
+enum LogMask {
+    Debug = 0x01,
+    Info = 0x02 + Debug,
+    Warning = 0x04 + Info,
+    Error = 0x08 + Warning,
+    All = 0xff
+};
+
+} // namespace detail
+
+// A manager for prestage requests
+//
+// The manager maintains a set of worker pools, one for each identifier.  When
+// the pool has been idle for a "reasonable" period, then it'll automatically
+// shut down.
+class PrestageRequestManager final {
+  public:
+    class PrestageRequest {
+      public:
+        PrestageRequest(const std::string &ident, const std::string &path,
+                        XrdOucEnv &env)
+            : m_ident(ident), m_path(path), m_env(env) {}
+
+        int WaitFor(std::chrono::steady_clock::duration);
+
+        XrdOucEnv &GetEnv() const { return m_env; }
+        std::string GetPath() const { return m_path; }
+        void SetProgress(off_t offset);
+        void SetDone(int status, const std::string &msg);
+        const std::string &GetIdentifier() const { return m_ident; }
+        bool IsActive() const {
+            return m_active.load(std::memory_order_relaxed);
+        }
+        std::string GetResults() const { return m_message; }
+        off_t GetProgress() const {
+            return m_prestage_offset.load(std::memory_order_relaxed);
+        }
+
+      private:
+        std::atomic<bool> m_active{false};
+        int m_status{-1};
+        std::atomic<off_t> m_prestage_offset{0};
+        std::string m_ident;
+        std::string m_path;
+        std::condition_variable m_cv;
+        std::mutex m_mutex;
+        std::string m_message;
+        XrdOucEnv &m_env;
+    };
+
+    PrestageRequestManager(XrdOucEnv &xrdEnv, XrdSysError &eDest);
+
+    bool Produce(PrestageRequest &handler);
+
+  private:
+    class PrestageQueue {
+        class PrestageWorker;
+
+      public:
+        PrestageQueue(const std::string &ident, PrestageRequestManager &parent,
+                      XrdOss &oss)
+            : m_oss(oss), m_parent(parent) {}
+
+        bool Produce(PrestageRequest &handler);
+        PrestageRequest &Consume();
+        PrestageRequest *TryConsume();
+        PrestageRequest *ConsumeUntil(std::chrono::steady_clock::duration dur);
+        void Done(PrestageWorker *);
+
+      private:
+        class PrestageWorker final {
+          public:
+            PrestageWorker(const std::string &label, XrdOss &oss,
+                           PrestageQueue &queue);
+            PrestageWorker(const PrestageWorker &) = delete;
+
+            void Run();
+            static void RunStatic(PrestageWorker *myself);
+
+          private:
+            void Prestage(PrestageRequest &request);
+
+            const std::string m_label;
+            XrdOss &m_oss;
+            PrestageQueue &m_queue;
+        };
+
+        int m_idle{0};
+        const std::string m_label;
+        XrdOss &m_oss;
+        std::vector<std::unique_ptr<PrestageWorker>> m_workers;
+        std::deque<PrestageRequest *> m_ops;
+        std::condition_variable m_cv;
+        std::mutex m_mutex;
+        PrestageRequestManager &m_parent;
+        const static unsigned m_max_pending_ops{20};
+        const static unsigned m_max_workers{20};
+    };
+
+    void Done(const std::string &ident);
+
+    static std::shared_mutex m_mutex;
+
+    static XrdOss *m_oss;
+
+    XrdSysError &m_log; // Log object for the prestage manager
+
+    static std::unordered_map<std::string, std::shared_ptr<PrestageQueue>>
+        m_pool_map;
+    static std::once_flag m_init_once;
+};
+
+class Handler : public XrdHttpExtHandler {
+  public:
+    Handler(XrdSysError *log, const char *config, XrdOucEnv *myEnv);
+    virtual ~Handler();
+
+    virtual bool MatchesPath(const char *verb, const char *path) override;
+    virtual int ProcessReq(XrdHttpExtReq &req) override;
+    virtual int Init(const char *cfgfile) override { return 0; }
+
+  private:
+    // A thread that does nothing but listens for the parent's pipe to
+    // close.  When it does close, send a SIGTERM to the existing
+    // process followed by a SIGTERM.
+    //
+    // This allows XRootD to auto-info when Pelican goes away.
+    void InfoThread();
+
+    // Process a prestage request from the remote client
+    int PrestageReq(const std::string &path, XrdHttpExtReq &req);
+
+    // Process a cache eviction request
+    int EvictReq(const std::string &path, XrdHttpExtReq &req);
+
+    // Indicates whether the plugin is running in a cache.
+    static bool m_is_cache;
+
+    // Ensure that the info thread is only started once.
+    static std::once_flag m_info_launch;
+
+    // The file descriptor to listen on for a pipe-based info.
+    static int m_info_fd;
+
+    // The location of the CA file for this process
+    static std::string m_ca_file;
+
+    // The location of the host certificate for this process
+    static std::string m_cert_file;
+
+    // Send a SIGTERM to self, followed by a 5 second sleep, followed
+    // by a SIGKILL (until the process exits).
+    void ShutdownSelf();
+
+    // Process a message from the info file descriptor; this pipe
+    // provides the ability for the parent process to update the CA
+    // and TLS certificate files.
+    void ProcessMessage();
+
+    // Atomically overwrite a location given a file descriptor with
+    // the new contents.
+    void AtomicOverwriteFile(int fd, const std::string &loc);
+
+    // Logger associated with the object
+    XrdSysError &m_log;
+
+    // Request manager object
+    PrestageRequestManager m_manager;
+
+    // Pointer to the global authorization object (used to authorize
+    // prestage/evict requests)
+    static XrdAccAuthorize *m_acc;
+
+    // Pointer to the global OFS instance (used to evict paths)
+    static XrdSfsFileSystem *m_sfs;
+
+    static std::filesystem::path m_api_root;
+};
+
+} // namespace XrdHttpPelican

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,34 @@ add_executable(xrdhttp-pelican-test xrdhttp_pelican_test.cc)
 target_link_libraries(xrdhttp-pelican-test XrdHttpPelicanTesting GTest::GTest GTest::Main)
 
 gtest_discover_tests(xrdhttp-pelican-test)
+
+add_test(NAME HTTP::pelican::setup
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/xrdhttp-setup.sh" pelican)
+
+set_tests_properties(HTTP::pelican::setup
+  PROPERTIES
+    FIXTURES_SETUP HTTP::pelican
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin"
+)
+
+add_test(NAME HTTP::pelican::teardown
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/xrdhttp-teardown.sh" pelican)
+
+set_tests_properties(HTTP::pelican::teardown
+  PROPERTIES
+    FIXTURES_CLEANUP HTTP::pelican
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR}"
+)
+
+add_test(NAME HTTP::pelican::test
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/xrdhttp-test.sh" pelican)
+
+list(APPEND BASIC_TEST_LOGS ${CMAKE_CURRENT_BINARY_DIR}/tests/pelican/server.log)
+list(APPEND BASIC_TEST_LOGS ${CMAKE_CURRENT_BINARY_DIR}/tests/pelican/client.log)
+
+set_tests_properties(HTTP::pelican::test
+  PROPERTIES
+    FIXTURES_REQUIRED HTTP::pelican
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR}"
+    ATTACHED_FILES_ON_FAIL "${BASIC_TEST_LOGS}"
+)

--- a/tests/xrdhttp-setup.sh
+++ b/tests/xrdhttp-setup.sh
@@ -1,0 +1,333 @@
+#!/bin/sh
+
+###############################
+# Helper functions for script #
+###############################
+
+server_port() {
+  logfile="$1"
+  xrootd_pid="$2"
+
+  touch -- "$logfile"
+  SERVER_PORT=$(grep "Xrd_ProtLoad: enabling port" "$logfile" | grep 'for protocol XrdHttp' | awk '{print $7}')
+  IDX=0
+  while [ -z "$SERVER_PORT" ]; do
+    sleep 1
+    SERVER_PORT=$(grep "Xrd_ProtLoad: enabling port" "$logfile" | grep 'for protocol XrdHttp' | awk '{print $7}')
+    IDX=$((IDX+1))
+    if ! kill -0 "$xrootd_pid" 2>/dev/null; then
+      echo "xrootd process (PID $xrootd_pid) failed to start" >&2
+      exit 1
+    fi
+    if [ $IDX -gt 1 ]; then
+      echo "Waiting for xrootd to start ($IDX seconds so far) ..." >&2
+    fi
+    if [ $IDX -eq 10 ]; then
+      echo "xrootd failed to start - failing" >&2
+      exit 1
+    fi
+  done
+
+  echo "$SERVER_PORT"
+}
+
+TEST_NAME="$1"
+
+HOSTNAME="${HOSTNAME:-$(hostname)}"
+
+if [ -z "$BINARY_DIR" ]; then
+  echo "\$BINARY_DIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ ! -d "$BINARY_DIR" ]; then
+  echo "$BINARY_DIR is not a directory; cannot run test"
+  exit 1
+fi
+if [ -z "$SOURCE_DIR" ]; then
+  echo "\$SOURCE_DIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "\$SOURCE_DIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ -z "$XROOTD_BINDIR" ]; then
+  echo "\$XROOTD_BINDIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ ! -d "$XROOTD_BINDIR" ]; then
+  echo "\$XROOTD_BINDIR environment variable is not set; cannot run test"
+  exit 1
+fi
+
+echo "Setting up origin and cache server for $TEST_NAME test"
+PATH="$(realpath "$XROOTD_BINDIR"):$PATH"
+XROOTD_BIN="$(command -v xrootd)"
+
+if [ -z "$XROOTD_BIN" ]; then
+  echo "xrootd binary not found; cannot run unit test"
+  exit 1
+fi
+
+mkdir -p "$BINARY_DIR/tests/$TEST_NAME"
+RUNDIR=$(mktemp -d -p "$BINARY_DIR/tests/$TEST_NAME" test_run.XXXXXXXX)
+
+if [ ! -d "$RUNDIR" ]; then
+  echo "Failed to create test run directory; cannot run xrootd"
+  exit 1
+fi
+
+echo "Using $RUNDIR as the test run's home directory."
+cd "$RUNDIR" || exit 1
+
+export XROOTD_CONFIGDIR="$RUNDIR/xrootd-config"
+mkdir -p "$XROOTD_CONFIGDIR/ca"
+
+echo > "$BINARY_DIR/tests/$TEST_NAME/server.log"
+
+############################################
+# Create the TLS credentials for the test  #
+############################################
+openssl genrsa -out "$XROOTD_CONFIGDIR/tlscakey.pem" 4096 >> "$BINARY_DIR/tests/$TEST_NAME/server.log"
+touch "$XROOTD_CONFIGDIR/ca/index.txt"
+echo '01' > "$XROOTD_CONFIGDIR/ca/serial.txt"
+
+cat > "$XROOTD_CONFIGDIR/tlsca.ini" <<EOF
+
+[ ca ]
+default_ca = CA_test
+
+[ CA_test ]
+
+default_days = 365
+default_md = sha256
+private_key = $XROOTD_CONFIGDIR/tlscakey.pem
+certificate = $XROOTD_CONFIGDIR/tlsca.pem
+new_certs_dir = $XROOTD_CONFIGDIR/ca
+database = $XROOTD_CONFIGDIR/ca/index.txt
+serial = $XROOTD_CONFIGDIR/ca/serial.txt
+
+[ req ]
+default_bits = 4096
+distinguished_name = ca_test_dn
+x509_extensions = ca_extensions
+string_mask = utf8only
+
+[ ca_test_dn ]
+
+commonName_default = Xrootd CA
+
+[ ca_extensions ]
+
+basicConstraints = critical,CA:true
+keyUsage = keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid
+
+[ signing_policy ]
+countryName            = optional
+stateOrProvinceName    = optional
+localityName           = optional
+organizationName       = optional
+organizationalUnitName = optional
+commonName             = supplied
+emailAddress           = optional
+
+[ cert_extensions ]
+
+basicConstraints = critical,CA:false
+keyUsage = digitalSignature
+extendedKeyUsage = critical, serverAuth, clientAuth
+
+EOF
+
+# Create the CA certificate
+if ! openssl req -x509 -key "$XROOTD_CONFIGDIR/tlscakey.pem" -config "$XROOTD_CONFIGDIR/tlsca.ini" -out "$XROOTD_CONFIGDIR/tlsca.pem" -outform PEM -subj "/CN=XRootD CA" 0<&- >> "$BINARY_DIR/tests/$TEST_NAME/server.log"; then
+  echo "Failed to generate CA request"
+  exit 1
+fi
+
+# Create the host certificate request
+openssl genrsa -out "$XROOTD_CONFIGDIR/tls.key" 4096 >> "$BINARY_DIR/tests/$TEST_NAME/server.log"
+if ! openssl req -new -key "$XROOTD_CONFIGDIR/tls.key" -config "$XROOTD_CONFIGDIR/tlsca.ini" -out "$XROOTD_CONFIGDIR/tls.csr" -outform PEM -subj "/CN=$(hostname)" 0<&- >> "$BINARY_DIR/tests/$TEST_NAME/server.log"; then
+  echo "Failed to generate host certificate request"
+  exit 1
+fi
+
+if ! openssl ca -config "$XROOTD_CONFIGDIR/tlsca.ini" -batch -policy signing_policy -extensions cert_extensions -out "$XROOTD_CONFIGDIR/tls.crt" -infiles "$XROOTD_CONFIGDIR/tls.csr" 0<&- 2>> "$BINARY_DIR/tests/$TEST_NAME/server.log"; then
+  echo "Failed to sign host certificate request"
+  exit 1
+fi
+
+
+# Create xrootd configuration and runtime directory structure
+XROOTD_EXPORTDIR="$RUNDIR/xrootd-export"
+mkdir -p "$XROOTD_EXPORTDIR"
+XROOTD_CACHEDIR="$RUNDIR/xrootd-cache"
+mkdir -p "$XROOTD_CACHEDIR"
+
+# XRootD has strict length limits on the admin path location.
+# Therefore, we also create a directory in /tmp.
+XROOTD_RUNDIR=$(mktemp -d -p /tmp xrootd_test.XXXXXXXX)
+mkdir -p "$XROOTD_RUNDIR/cache"
+mkdir -p "$XROOTD_RUNDIR/origin"
+
+###########################
+# Setup the XRootD origin #
+###########################
+export XROOTD_CONFIG="$XROOTD_CONFIGDIR/xrootd-origin.cfg"
+cat > "$XROOTD_CONFIG" <<EOF
+
+all.trace    all
+http.trace   all
+xrd.trace    all
+xrootd.trace all
+scitokens.trace all
+
+xrd.port any
+
+all.export /
+all.sitename  XRootD
+all.adminpath $XROOTD_RUNDIR/origin
+all.pidpath   $XROOTD_RUNDIR/origin
+
+xrootd.seclib libXrdSec.so
+
+ofs.authorize 1
+
+ofs.authlib ++ libXrdAccSciTokens.so config=$XROOTD_CONFIGDIR/scitokens.cfg
+acc.authdb $XROOTD_CONFIGDIR/authdb
+
+xrd.protocol XrdHttp:any libXrdHttp.so
+http.header2cgi Authorization authz
+
+xrd.tlsca certfile $XROOTD_CONFIGDIR/tlsca.pem
+xrd.tls $XROOTD_CONFIGDIR/tls.crt $XROOTD_CONFIGDIR/tls.key
+
+oss.localroot $XROOTD_EXPORTDIR
+
+http.exthandler xrdpelican $BINARY_DIR/libXrdHttpPelican.so
+
+EOF
+
+cat > "$XROOTD_CONFIGDIR/authdb" <<EOF
+
+u * / lr
+
+EOF
+
+cat > "$XROOTD_CONFIGDIR/scitokens.cfg" <<EOF
+
+[Global]
+audience = https://demo.scitokens.org
+
+[Issuer DEMO]
+issuer = https://demo.scitokens.org
+base_path = /
+
+EOF
+
+# Export some data through the origin
+echo "Hello, World" > "$XROOTD_EXPORTDIR/hello_world.txt"
+
+#####################
+# Launch the origin #
+#####################
+echo > "$BINARY_DIR/tests/$TEST_NAME/origin.log"
+"$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/origin.log" 0<&- >>"$BINARY_DIR/tests/$TEST_NAME/server.log" 2>&1 &
+ORIGIN_PID=$!
+echo "origin PID: $ORIGIN_PID"
+echo "XRootD origin logs are available at $BINARY_DIR/tests/$TEST_NAME/origin.log"
+ORIGIN_PORT=$(server_port "$BINARY_DIR/tests/$TEST_NAME/origin.log" "$ORIGIN_PID")
+if [ -z "$ORIGIN_PORT" ]; then
+  exit 1
+fi
+ORIGIN_URL="https://$HOSTNAME:$ORIGIN_PORT/"
+echo "origin started at $ORIGIN_URL"
+
+#####################################
+# Write out the cache configuration #
+#####################################
+
+cat > "$XROOTD_CONFIGDIR/cache-authdb" <<EOF
+
+u * / a
+
+EOF
+
+export XROOTD_CONFIG="$XROOTD_CONFIGDIR/xrootd-cache.cfg"
+cat > "$XROOTD_CONFIG" <<EOF
+
+all.trace    all
+http.trace   all
+xrd.trace    all
+xrootd.trace all
+pfc.trace debug
+scitokens.trace all
+
+xrd.port any
+
+all.export /
+all.sitename  XRootD
+all.adminpath $XROOTD_RUNDIR/cache
+all.pidpath   $XROOTD_RUNDIR/cache
+
+xrootd.seclib libXrdSec.so
+
+ofs.authorize 1
+
+ofs.authlib ++ libXrdAccSciTokens.so config=$XROOTD_CONFIGDIR/scitokens.cfg
+acc.authdb $XROOTD_CONFIGDIR/cache-authdb
+
+xrd.protocol XrdHttp:any libXrdHttp.so
+http.header2cgi Authorization authz
+
+xrd.tlsca certfile $XROOTD_CONFIGDIR/tlsca.pem
+xrd.tls $XROOTD_CONFIGDIR/tls.crt $XROOTD_CONFIGDIR/tls.key
+
+http.header2cgi Authorization authz
+http.header2cgi X-Pelican-Timeout pelican.timeout
+
+oss.localroot $XROOTD_CACHEDIR
+
+pfc.blocksize 128k
+pfc.prefetch 20
+pfc.writequeue 16 4
+pfc.ram 4g
+pss.setopt DebugLevel 4
+pfc.diskusage 0.90 0.95 purgeinterval 300s
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+pss.origin $HOSTNAME:$ORIGIN_PORT
+
+pelican.trace debug
+
+http.exthandler xrdpelican $BINARY_DIR/libXrdHttpPelican.so
+EOF
+
+####################
+# Launch the cache #
+####################
+echo > "$BINARY_DIR/tests/$TEST_NAME/cache.log"
+"$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/cache.log" 0<&- >>"$BINARY_DIR/tests/$TEST_NAME/server.log" 2>&1 &
+CACHE_PID=$!
+echo "cache PID: $CACHE_PID"
+echo "XRootD cache logs are available at $BINARY_DIR/tests/$TEST_NAME/cache.log"
+CACHE_PORT=$(server_port "$BINARY_DIR/tests/$TEST_NAME/cache.log" "$CACHE_PID")
+if [ -z "$CACHE_PORT" ]; then
+  exit 1
+fi
+CACHE_URL="https://$HOSTNAME:$CACHE_PORT/"
+echo "cache started at $CACHE_URL"
+
+cat > "$BINARY_DIR/tests/$TEST_NAME/setup.sh" <<EOF
+XROOTD_BIN=$XROOTD_BIN
+ORIGIN_PID=$ORIGIN_PID
+CACHE_PID=$CACHE_PID
+ORIGIN_URL=$ORIGIN_URL
+CACHE_URL=$CACHE_URL
+X509_CA_FILE=$XROOTD_CONFIGDIR/tlsca.pem
+XROOTD_CACHEDIR=$XROOTD_CACHEDIR
+EOF
+
+echo "Test environment written to $BINARY_DIR/tests/$TEST_NAME/setup.sh"

--- a/tests/xrdhttp-setup.sh
+++ b/tests/xrdhttp-setup.sh
@@ -23,7 +23,8 @@ server_port() {
       echo "Waiting for xrootd to start ($IDX seconds so far) ..." >&2
     fi
     if [ $IDX -eq 10 ]; then
-      echo "xrootd failed to start - failing" >&2
+      echo "xrootd failed to start - dumping logs and failing" >&2
+      cat "$logfile" >&2
       exit 1
     fi
   done

--- a/tests/xrdhttp-teardown.sh
+++ b/tests/xrdhttp-teardown.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+TEST_NAME=$1
+
+if [ -z "$BINARY_DIR" ]; then
+  echo "\$BINARY_DIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ ! -d "$BINARY_DIR" ]; then
+  echo "$BINARY_DIR is not a directory; cannot run test"
+  exit 1
+fi
+
+echo "Tearing down $TEST_NAME"
+
+if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
+  echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
+  exit 1
+fi
+. "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+
+
+if [ -z "$ORIGIN_PID" ]; then
+  echo "\$ORIGIN_PID environment variable is not set; cannot tear down process"
+  exit 0
+fi
+kill "$CACHE_PID"
+
+if [ -z "$CACHE_PID" ]; then
+  echo "\$CACHE_PID environment variable is not set; cannot tear down process"
+  exit 1
+fi
+kill "$CACHE_PID"

--- a/tests/xrdhttp-test.sh
+++ b/tests/xrdhttp-test.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+
+TEST_NAME=$1
+
+if [ -z "$BINARY_DIR" ]; then
+  echo "\$BINARY_DIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ ! -d "$BINARY_DIR" ]; then
+  echo "$BINARY_DIR is not a directory; cannot run test"
+  exit 1
+fi
+
+if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
+  echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
+  exit 1
+fi
+. "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+
+
+#############################
+# Downloads from the origin #
+#############################
+echo "Running $TEST_NAME - origin download"
+
+CONTENTS=$(curl --cacert $X509_CA_FILE -v --fail "$ORIGIN_URL/hello_world.txt" 2> "$BINARY_DIR/tests/$TEST_NAME/client.log")
+CURL_EXIT=$?
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Download of hello-world text failed"
+  exit 1
+fi
+
+if [ "$CONTENTS" != "Hello, World" ]; then
+  echo "Downloaded hello-world text is incorrect: $CONTENTS"
+  exit 1
+fi
+
+echo "Running $TEST_NAME - missing object"
+
+HTTP_CODE=$(curl --cacert $X509_CA_FILE --output /dev/null -v --write-out '%{http_code}' "$ORIGIN_URL/missing.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log")
+if [ "$HTTP_CODE" -ne 404 ]; then
+  echo "Expected HTTP code is 404; actual was $HTTP_CODE"
+  exit 1
+fi
+
+############################
+# Downloads from the cache #
+############################
+echo "Running $TEST_NAME - cache download"
+
+CONTENTS=$(curl --cacert $X509_CA_FILE -v --fail "$CACHE_URL/hello_world.txt" 2> "$BINARY_DIR/tests/$TEST_NAME/client.log")
+CURL_EXIT=$?
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Download of hello-world text failed"
+  exit 1
+fi
+
+if [ "$CONTENTS" != "Hello, World" ]; then
+  echo "Downloaded hello-world text is incorrect: $CONTENTS"
+  exit 1
+fi
+
+echo "Running $TEST_NAME - missing object"
+
+HTTP_CODE=$(curl --cacert $X509_CA_FILE --output /dev/null -v --write-out '%{http_code}' "$CACHE_URL/missing.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log")
+if [ "$HTTP_CODE" -ne 404 ]; then
+  echo "Expected HTTP code is 404; actual was $HTTP_CODE"
+  exit 1
+fi
+
+###########################
+# Test the cache eviction #
+###########################
+
+echo "Ensure the object is cached in the local directory"
+
+CONTENTS=$(cat "$XROOTD_CACHEDIR/hello_world.txt")
+
+if [ "$CONTENTS" != "Hello, World" ]; then
+  echo "Cached hello-world text is incorrect: $CONTENTS"
+  exit 1
+fi
+
+echo "Running $TEST_NAME - evict from cache"
+
+HTTP_CODE=$(curl --cacert $X509_CA_FILE --output /dev/null -v --write-out '%{http_code}' "$CACHE_URL/pelican/api/v1.0/evict?path=/hello_world.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log")
+if [ "$HTTP_CODE" -ne 200 ]; then
+  echo "Expected HTTP code is 200; actual was $HTTP_CODE"
+  exit 1
+fi
+
+if [ -f "$XROOTD_CACHEDIR/hello_world.txt" ]; then
+  echo "Cached hello-world text was not evicted"
+  exit 1
+fi
+
+###########################
+# Test the cache prestage #
+###########################
+
+echo "Running $TEST_NAME - prestage to cache"
+
+HTTP_CODE=$(curl --cacert $X509_CA_FILE --output /dev/null -v --write-out '%{http_code}' "$CACHE_URL/pelican/api/v1.0/prestage?path=/hello_world.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log")
+if [ "$HTTP_CODE" -ne 200 ]; then
+  echo "Expected HTTP code is 200; actual was $HTTP_CODE"
+  exit 1
+fi
+
+if [ ! -f "$XROOTD_CACHEDIR/hello_world.txt" ]; then
+  echo "hello-world text was not prestaged"
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a prestage and an eviction API to the plugin along with some simple integration tests to ensure that the plugin works.

Importantly, there were some issues uncovered in the development of the integration test that are needed to get `xrdhttp-pelican` working in the prior use case.

@h2zh - this is the work I had mentioned earlier today.