### PR TITLE
Improve prestage implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ find_package( XRootD REQUIRED )
 
 set (CMAKE_CXX_STANDARD 20)
 
+if( ENABLE_ASAN )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fsanitize=address")
+endif()
+
 find_package( Threads REQUIRED )
 
 if( CMAKE_BUILD_TYPE STREQUAL Debug )

--- a/src/Prestage.cc
+++ b/src/Prestage.cc
@@ -35,6 +35,10 @@ decltype(PrestageRequestManager::m_init_once)
     PrestageRequestManager::m_init_once;
 decltype(PrestageRequestManager::m_oss) PrestageRequestManager::m_oss;
 decltype(PrestageRequestManager::m_mutex) PrestageRequestManager::m_mutex;
+decltype(PrestageRequestManager::m_idle_timeout)
+    PrestageRequestManager::m_idle_timeout = std::chrono::minutes(1);
+unsigned PrestageRequestManager::m_max_pending_ops = 20;
+unsigned PrestageRequestManager::m_max_workers = 20;
 
 PrestageRequestManager::PrestageQueue::PrestageWorker::PrestageWorker(
     const std::string &label, XrdOss &oss, PrestageQueue &queue)
@@ -84,10 +88,13 @@ void PrestageRequestManager::PrestageQueue::PrestageWorker::Prestage(
 }
 
 void PrestageRequestManager::PrestageQueue::PrestageWorker::Run() {
+    m_queue.m_parent.m_log.Log(LogMask::Info, "PrestageWorker", "Worker for",
+                               m_queue.m_label.c_str(), "starting");
+
     while (true) {
         auto request = m_queue.TryConsume();
         if (!request) {
-            request = m_queue.ConsumeUntil(std::chrono::minutes(1));
+            request = m_queue.ConsumeUntil(m_idle_timeout, this);
             if (!request) {
                 break;
             }
@@ -95,22 +102,27 @@ void PrestageRequestManager::PrestageQueue::PrestageWorker::Run() {
         Prestage(*request);
     }
 
+    m_queue.m_parent.m_log.Log(LogMask::Info, "PrestageWorker", "Worker for",
+                               m_queue.m_label.c_str(), "exiting");
     m_queue.Done(this);
 }
 
 void PrestageRequestManager::PrestageQueue::Done(PrestageWorker *worker) {
     std::unique_lock lock(m_mutex);
-    m_idle--;
+    m_done = true;
     std::erase_if(m_workers, [&](std::unique_ptr<PrestageWorker> &other) {
         return other.get() == worker;
     });
 
     if (m_workers.empty()) {
+        lock.unlock();
         m_parent.Done(m_label);
     }
 }
 
 void PrestageRequestManager::Done(const std::string &ident) {
+    m_log.Log(LogMask::Info, "PrestageRequestManager", "Prestage pool",
+              ident.c_str(), "is idle and all workers have exited.");
     std::unique_lock lock(m_mutex);
 
     auto iter = m_pool_map.find(ident);
@@ -119,41 +131,50 @@ void PrestageRequestManager::Done(const std::string &ident) {
     }
 }
 
+// Produce a request for processing.  If the queue is full, the request will
+// be rejected and false will be returned.
+//
+// Implementation notes:
+// - If a worker is idle, it will be woken up to process the request.
+// - If no workers are idle, a new worker will be created to process the
+//   request.
+// - If the maximum number of workers is reached, the request will be queued
+//   until a worker is available.
+// - If the maximum number of pending operations is reached, the request will
+//   be rejected.
+// - If there are multiple idle workers, the oldest worker will be woken.  This
+//   causes the newest workers to be idle for as long as possible and
+//   potentially exit due to lack of work.  This is done to reduce the number of
+//   "mostly idle" workers in the thread pool.
 bool PrestageRequestManager::PrestageQueue::Produce(PrestageRequest &handler) {
     std::unique_lock lk{m_mutex};
     if (m_ops.size() == m_max_pending_ops) {
+        m_parent.m_log.Log(LogMask::Warning, "PrestageQueue",
+                           "Queue is full; rejecting request");
         return false;
     }
 
     m_ops.push_back(&handler);
-    m_cv.notify_one();
+    for (auto &worker : m_workers) {
+        if (worker->IsIdle()) {
+            worker->m_cv.notify_one();
+            return true;
+        }
+    }
 
-    if (!m_idle && m_workers.size() < m_max_workers) {
-        m_workers.push_back(
-            std::make_unique<
-                PrestageRequestManager::PrestageQueue::PrestageWorker>(
-                handler.GetIdentifier(), m_oss, *this));
+    if (m_workers.size() < m_max_workers) {
+        auto worker = std::make_unique<
+            PrestageRequestManager::PrestageQueue::PrestageWorker>(
+            handler.GetIdentifier(), m_oss, *this);
         std::thread t(
             PrestageRequestManager::PrestageQueue::PrestageWorker::RunStatic,
-            m_workers.back().get());
+            worker.get());
         t.detach();
+        m_workers.push_back(std::move(worker));
     }
     lk.unlock();
 
     return true;
-}
-
-PrestageRequestManager::PrestageRequest &
-PrestageRequestManager::PrestageQueue::Consume() {
-    std::unique_lock<std::mutex> lk(m_mutex);
-    m_idle++;
-    m_cv.wait(lk, [&] { return m_ops.size() > 0; });
-    m_idle--;
-
-    auto result = std::move(m_ops.front());
-    m_ops.pop_front();
-
-    return *result;
 }
 
 PrestageRequestManager::PrestageRequest *
@@ -169,13 +190,18 @@ PrestageRequestManager::PrestageQueue::TryConsume() {
     return result;
 }
 
+// Wait for a request to be available for processing, or until the duration
+// has elapsed.
+//
+// Returns the request that is available, or nullptr if the duration has
+// elapsed.
 PrestageRequestManager::PrestageRequest *
 PrestageRequestManager::PrestageQueue::ConsumeUntil(
-    std::chrono::steady_clock::duration dur) {
+    std::chrono::steady_clock::duration dur, PrestageWorker *worker) {
     std::unique_lock<std::mutex> lk(m_mutex);
-    m_idle++;
-    m_cv.wait_for(lk, dur, [&] { return m_ops.size() > 0; });
-    m_idle--;
+    worker->SetIdle(true);
+    worker->m_cv.wait_for(lk, dur, [&] { return m_ops.size() > 0; });
+    worker->SetIdle(false);
     if (m_ops.size() == 0) {
         return nullptr;
     }
@@ -219,6 +245,14 @@ PrestageRequestManager::PrestageRequestManager(XrdOucEnv &xrdEnv,
     });
 }
 
+void PrestageRequestManager::SetWorkerIdleTimeout(
+    std::chrono::steady_clock::duration dur) {
+    m_idle_timeout = dur;
+}
+
+// Send a request to a worker for processing.  If the worker is not available,
+// the request will be queued until a worker is available.  If the queue is
+// full, the request will be rejected and false will be returned.
 bool PrestageRequestManager::Produce(
     PrestageRequestManager::PrestageRequest &handler) {
 
@@ -230,23 +264,41 @@ bool PrestageRequestManager::Produce(
     }
 
     std::shared_ptr<PrestageQueue> queue;
-    {
+    // Get the queue from our per-label map.  To avoid a race condition,
+    // if the queue we get has already been shut down, we release the lock
+    // and try again (with the expectation that the queue will eventually
+    // get the lock and remove itself from the map).
+    while (true) {
         m_mutex.lock_shared();
         std::lock_guard guard{m_mutex, std::adopt_lock};
         auto iter = m_pool_map.find(handler.GetIdentifier());
         if (iter != m_pool_map.end()) {
             queue = iter->second;
+            if (!queue->IsDone())
+                break;
+        } else {
+            break;
         }
     }
     if (!queue) {
-        std::lock_guard guard(m_mutex);
-        auto iter = m_pool_map.find(handler.GetIdentifier());
-        if (iter == m_pool_map.end()) {
-            queue = std::make_shared<PrestageQueue>(handler.GetIdentifier(),
-                                                    *this, *m_oss);
-            m_pool_map.insert(iter, {handler.GetIdentifier(), queue});
-        } else {
-            queue = iter->second;
+        auto created_queue = false;
+        std::string queue_name = "";
+        {
+            std::lock_guard guard(m_mutex);
+            auto iter = m_pool_map.find(handler.GetIdentifier());
+            if (iter == m_pool_map.end()) {
+                queue = std::make_shared<PrestageQueue>(handler.GetIdentifier(),
+                                                        *this, *m_oss);
+                m_pool_map.insert(iter, {handler.GetIdentifier(), queue});
+                created_queue = true;
+                queue_name = handler.GetIdentifier();
+            } else {
+                queue = iter->second;
+            }
+        }
+        if (created_queue) {
+            m_log.Log(LogMask::Info, "RequestManager",
+                      "Created new prestage queue for", queue_name.c_str());
         }
     }
     return queue->Produce(handler);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,11 @@ include_directories(${XRootD_INCLUDE_DIR})
 add_executable(xrdhttp-pelican-test xrdhttp_pelican_test.cc)
 target_link_libraries(xrdhttp-pelican-test XrdHttpPelicanTesting GTest::GTest GTest::Main)
 
+add_library( XrdOssSlowOpen MODULE xrdoss_slowopen.cc )
+target_include_directories( XrdOssSlowOpen PRIVATE ${XRootD_INCLUDE_DIRS} )
+target_link_libraries( XrdOssSlowOpen ${XRootD_UTILS_LIBRARIES} ${XRootD_SERVER_LIBRARIES} )
+set_target_properties( XrdOssSlowOpen PROPERTIES OUTPUT_NAME "XrdOssSlowOpen-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
+
 gtest_discover_tests(xrdhttp-pelican-test)
 
 add_test(NAME HTTP::pelican::setup

--- a/tests/xrdhttp-setup.sh
+++ b/tests/xrdhttp-setup.sh
@@ -205,6 +205,7 @@ http.header2cgi Authorization authz
 xrd.tlsca certfile $XROOTD_CONFIGDIR/tlsca.pem
 xrd.tls $XROOTD_CONFIGDIR/tls.crt $XROOTD_CONFIGDIR/tls.key
 
+ofs.osslib ++ $BINARY_DIR/tests/libXrdOssSlowOpen.so
 oss.localroot $XROOTD_EXPORTDIR
 
 http.exthandler xrdpelican $BINARY_DIR/libXrdHttpPelican.so
@@ -230,6 +231,10 @@ EOF
 
 # Export some data through the origin
 echo "Hello, World" > "$XROOTD_EXPORTDIR/hello_world.txt"
+
+for idx in $(seq 1 10); do
+  dd if=/dev/urandom of="$XROOTD_EXPORTDIR/random_data_$idx.txt" bs=1024 count=4096 2> /dev/null
+done
 
 #####################
 # Launch the origin #
@@ -302,6 +307,9 @@ pss.cachelib libXrdPfc.so
 pss.origin $HOSTNAME:$ORIGIN_PORT
 
 pelican.trace debug
+pelican.worker_idle 10ms
+pelican.worker_max 2
+pelican.idle_request_max 2
 
 http.exthandler xrdpelican $BINARY_DIR/libXrdHttpPelican.so
 EOF

--- a/tests/xrdhttp-test.sh
+++ b/tests/xrdhttp-test.sh
@@ -106,7 +106,67 @@ if [ "$HTTP_CODE" -ne 200 ]; then
   exit 1
 fi
 
+if ! grep -q "pelican_Prestage: Handling prestage for path /hello_world.txt" "$BINARY_DIR/tests/$TEST_NAME/cache.log"; then
+  echo "Prestage request was not logged"
+  exit 1
+fi
+
+if ! grep -q "pelican_RequestManager: Created new prestage queue for nobody" "$BINARY_DIR/tests/$TEST_NAME/cache.log"; then
+  echo "Prestage request queue was not created"
+  exit 1
+fi
+
 if [ ! -f "$XROOTD_CACHEDIR/hello_world.txt" ]; then
   echo "hello-world text was not prestaged"
+  exit 1
+fi
+
+sleep 1
+
+if ! grep -q "pelican_PrestageRequestManager: Prestage pool nobody is idle and all workers have exited" "$BINARY_DIR/tests/$TEST_NAME/cache.log"; then
+  echo "Prestage request manager did not exit on idle"
+  exit 1
+fi
+
+###########################
+# Test parallel prestage  #
+###########################
+
+echo "Running $TEST_NAME - parallel prestage to cache"
+
+for idx in $(seq 1 10); do
+  curl --cacert $X509_CA_FILE --output /dev/null -v --write-out '%{http_code}' "$CACHE_URL/pelican/api/v1.0/prestage?path=/random_data_$idx.txt" > "$BINARY_DIR/tests/$TEST_NAME/download_results_${idx}.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log" &
+done
+
+wait
+
+COUNT_429=0
+NOT_STAGED_COUNT=0
+for idx in $(seq 1 10); do
+  HTTP_CODE=$(cat "$BINARY_DIR/tests/$TEST_NAME/download_results_${idx}.txt")
+  if [ "$HTTP_CODE" -ne 200 ] && [ "$HTTP_CODE" -ne 429 ]; then
+    echo "Expected HTTP codes are either 200 or 429; actual was $HTTP_CODE"
+    exit 1
+  fi
+  if [ "$HTTP_CODE" -eq 429 ]; then
+    COUNT_429=$((COUNT_429+1))
+  fi
+  if [ ! -f "$XROOTD_CACHEDIR/random_data_${idx}.txt" ]; then
+    NOT_STAGED_COUNT=$((NOT_STAGED_COUNT+1))
+  fi
+done
+if [ "$COUNT_429" -eq 0 ]; then
+  echo "Expected at least one 429 response; actual was $COUNT_429"
+  exit 1
+fi
+echo "$COUNT_429 files were not staged due to load (expected)"
+if [ "$COUNT_429" -ne "$NOT_STAGED_COUNT" ]; then
+  echo "Expected $COUNT_429 files to not be staged; actual was $NOT_STAGED_COUNT"
+  exit 1
+fi
+
+WORKERS_STARTED=$(grep -c "for nobody starting" "$BINARY_DIR/tests/$TEST_NAME/cache.log")
+if [ "$WORKERS_STARTED" -lt 3 ]; then
+  echo "Expected at least 3 workers to be started; actual was $WORKERS_STARTED"
   exit 1
 fi

--- a/tests/xrdoss_slowopen.cc
+++ b/tests/xrdoss_slowopen.cc
@@ -1,0 +1,77 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+//
+// An OSS meant for unit tests.
+// Currently, all it does is delay opens by 100ms.
+//
+
+#include "XrdOss/XrdOssWrapper.hh"
+#include "XrdVersion.hh"
+
+#include <memory>
+#include <unistd.h>
+
+namespace {
+
+class File final : public XrdOssWrapDF {
+  public:
+    File(std::unique_ptr<XrdOssDF> wrapDF)
+        : XrdOssWrapDF(*wrapDF), m_wrapped(std::move(wrapDF)) {}
+
+    virtual ~File() {}
+
+    int Open(const char *path, int Oflag, mode_t Mode,
+             XrdOucEnv &env) override {
+        usleep(100'000); // 100ms
+        return wrapDF.Open(path, Oflag, Mode, env);
+    }
+
+  private:
+    std::unique_ptr<XrdOssDF> m_wrapped;
+};
+
+class FileSystem final : public XrdOssWrapper {
+  public:
+    FileSystem(XrdOss *oss, XrdSysLogger *log, XrdOucEnv *envP)
+        : XrdOssWrapper(*oss), m_oss(oss) {}
+
+    virtual ~FileSystem() {}
+
+    XrdOssDF *newFile(const char *user = 0) override {
+        std::unique_ptr<XrdOssDF> wrapped(wrapPI.newFile(user));
+        return new File(std::move(wrapped));
+    }
+
+  private:
+    std::unique_ptr<XrdOss> m_oss;
+};
+
+} // namespace
+
+extern "C" {
+
+XrdOss *XrdOssAddStorageSystem2(XrdOss *curr_oss, XrdSysLogger *logger,
+                                const char *config_fn, const char *parms,
+                                XrdOucEnv *envP) {
+    return new FileSystem(curr_oss, logger, envP);
+}
+
+XrdVERSIONINFO(XrdOssAddStorageSystem2, slowfs);
+
+} // extern "C"


### PR DESCRIPTION
- Add unit tests for the queue being full and multiple downloaders.
- Provide consistent wakeup ordering of waiters, keeping newer workers idle and increasing the likelihood they are shutdown.
- Fix a small concurrency bug that could have led to deadlock when a queue is shutting down.