### PR TITLE
Handle authfile and SciTokens config file

### DIFF
--- a/src/XrdHttpPelican.cc
+++ b/src/XrdHttpPelican.cc
@@ -527,7 +527,7 @@ void Handler::ProcessMessage() {
                        "Failed to send signal to self:", strerror(errno));
         }
         return;
-    } else if (data < 0 || data > 7) {
+    } else if (data <= 0 || data > 7) {
         m_log.Emsg("ProcessMessage", "Unknown control message from parent:",
                    std::to_string(data).c_str());
         return;

--- a/src/XrdHttpPelican.cc
+++ b/src/XrdHttpPelican.cc
@@ -527,8 +527,7 @@ void Handler::ProcessMessage() {
                        "Failed to send signal to self:", strerror(errno));
         }
         return;
-    } else if (data != 1 && data != 2 && data != 4 && data != 5 && 
-               data != 6 && data != 7) {
+    } else if (data < 0 || data > 7) {
         m_log.Emsg("ProcessMessage", "Unknown control message from parent:",
                    std::to_string(data).c_str());
         return;

--- a/src/XrdHttpPelican.hh
+++ b/src/XrdHttpPelican.hh
@@ -210,6 +210,12 @@ class Handler : public XrdHttpExtHandler {
     // The location of the cache self-test file cinfo
     static std::string m_cache_self_test_file_cinfo;
 
+    // The location of the generated auth file
+    static std::string m_authfile_generated;
+    
+    // The location of the generated scitokens file
+    static std::string m_scitokens_generated;
+
     // Send a SIGTERM to self, followed by a 5 second sleep, followed
     // by a SIGKILL (until the process exits).
     void ShutdownSelf();


### PR DESCRIPTION
Use xrdhttp-pelican to move authfile and SciTokens config file into the directories owned by xrootd user.

This PR works together with https://github.com/PelicanPlatform/pelican/pull/2291 