### PR TITLE
Handle federation token file in drop-privileges mode

### DIFF
--- a/src/XrdHttpPelican.hh
+++ b/src/XrdHttpPelican.hh
@@ -222,6 +222,9 @@ class Handler : public XrdHttpExtHandler {
     // The executable path for re-exec
     static std::string m_executable_path;
 
+    // The location of the federation token file
+    static std::string m_fedtoken_file;
+
     // Send a SIGTERM to self, followed by a 5 second sleep, followed
     // by a SIGKILL (until the process exits).
     void ShutdownSelf();


### PR DESCRIPTION
Create a new xrdhttp-pelican command "9" to move and rename the intermediate federation token file into a consistent directory that xrootd user can access.

This PR works together with https://github.com/PelicanPlatform/pelican/pull/3061